### PR TITLE
Feat/update position

### DIFF
--- a/client/api.js
+++ b/client/api.js
@@ -57,9 +57,7 @@ export const api = {
       );
     },
     log(boardId) {
-      return fetch(`${API_ENDPOINT}/logs/${boardId}`).then((res) => 
-        res.json()
-      );
+      return fetch(`${API_ENDPOINT}/logs/${boardId}`).then((res) => res.json());
     },
   },
   update: {
@@ -67,8 +65,17 @@ export const api = {
     board() {},
     list() {},
     itemContent(itemId, itemData) {
-      return fetch(`${API_ENDPOINT}/items/${itemId}`, {
+      return fetch(`${API_ENDPOINT}/items/${itemId}/content`, {
         method: "PUT",
+        body: JSON.stringify(itemData),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }).then((res) => res.json());
+    },
+    itemPosition(itemData) {
+      return fetch(`${API_ENDPOINT}/items/${itemData.itemId}/position`, {
+        method: "PATCH",
         body: JSON.stringify(itemData),
         headers: {
           "Content-Type": "application/json",

--- a/client/component/App/Main/Board/List/List.js
+++ b/client/component/App/Main/Board/List/List.js
@@ -72,7 +72,7 @@ export default class List {
       const { board_id, list_id, list_title: from_list } = this.data;
       const itemData = {
         content: content,
-        position: 1,
+        position: parseInt(this.list.querySelector(".counter").innerText) + 1,
         board_id,
         list_id,
         performer_id: 1,

--- a/client/component/App/Main/Board/List/List.js
+++ b/client/component/App/Main/Board/List/List.js
@@ -20,6 +20,8 @@ export default class List {
     target.insertAdjacentElement("afterbegin", list);
     this.list = list;
     this.data = null;
+
+    this.list.addEventListener("click", this.handleListClick.bind(this));
   }
 
   setState(data) {
@@ -45,18 +47,22 @@ export default class List {
     const classes = Array.from(classList);
     if (classes.includes("item-add-btn")) {
       this.openItemCreationSection();
+      return;
     }
     if (classes.includes("cancel-btn")) {
       this.resetItemCreationSection();
       this.closeItemCreationSection();
+      return;
     }
     if (classes.includes("confirm-btn")) {
       this.handleItemSubmission();
+      return;
     }
     if (tagName === "TEXTAREA") {
       this.list
         .querySelector("textarea")
         .addEventListener("input", this.handleInputChange.bind(this));
+      return;
     }
   }
 
@@ -205,8 +211,6 @@ export default class List {
       </section>
       <section class="items"></section>
     `;
-
-    this.list.addEventListener("click", this.handleListClick.bind(this));
 
     const itemContainer = this.list.querySelector(".items");
     validItems.forEach((item) => {

--- a/client/utils/drag-drop/drag-drop.js
+++ b/client/utils/drag-drop/drag-drop.js
@@ -1,3 +1,5 @@
+import { api } from "../../api";
+
 export default function () {
   let selectedElem,
     draggableItem,
@@ -36,9 +38,49 @@ export default function () {
     selectedElem.classList.add("shadow");
   };
 
+  const fetchPositionInListUpdate = async function (itemId, order, list) {
+    const itemData = {
+      itemId,
+      order,
+      list,
+    };
+    try {
+      await api.update.itemPosition(itemData).then((data) => console.log(data));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const fetchChangeList = function () {};
+
+  const changePosition = function (origin, current) {
+    const originList = document.querySelectorAll(".list")[origin.list - 1];
+    const originListLength = originList.querySelectorAll(".item").length;
+    const currentList = document.querySelectorAll(".list")[current.list - 1];
+    const currentListLength = currentList.querySelectorAll(".item").length;
+
+    currentList.querySelectorAll(".item").forEach((item, idx) => {
+      const itemId = item.dataset.id;
+      const newOrder = currentListLength - idx;
+      item.dataset.order = newOrder;
+      item.dataset.list = current.list;
+      fetchPositionInListUpdate(itemId, newOrder, current.list);
+    });
+
+    if (originList !== currentList) {
+      originList.querySelectorAll(".item").forEach((item, idx) => {
+        const itemId = item.dataset.id;
+        const newOrder = originListLength - idx;
+        item.dataset.order = newOrder;
+        item.dataset.list = origin.list;
+        fetchPositionInListUpdate(itemId, newOrder, origin.list);
+      });
+    }
+  };
+
   const checkMovement = function () {
     const {
-      data: { list, order },
+      dataset: { list, order },
     } = selectedElem;
     const originInfo = {
       list,
@@ -48,18 +90,17 @@ export default function () {
     const currListItems = currList.querySelectorAll(".item");
     const currOrder = Array.from(currListItems).indexOf(selectedElem);
     const currentInfo = {
-      list: currList.data.order,
+      list: currList.dataset.id,
       order: currOrder,
     };
-    // 업데이트 api
-    // dataset 변경
+    changePosition(originInfo, currentInfo);
   };
 
   const handleMouseUp = function (e) {
     draggableItem.remove();
     selectedElem.classList.remove("shadow");
-    reset();
     checkMovement();
+    reset();
   };
 
   const locator = function () {

--- a/server/app.js
+++ b/server/app.js
@@ -10,7 +10,7 @@ const router = require("./routes");
 const setHeader = function (req, res, next) {
   res.header("Access-Control-Allow-Origin", "*");
   res.header("Access-Control-Allow-Headers", "Content-Type");
-  res.header("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");
+  res.header("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT, PATCH");
   next();
 };
 

--- a/server/controller/item.js
+++ b/server/controller/item.js
@@ -29,7 +29,7 @@ exports.create = async (req, res) => {
   res.send({ insertedItem, insertedLog });
 };
 
-exports.update = async (req, res) => {
+exports.updateContent = async (req, res) => {
   const {
     content,
     position,
@@ -60,6 +60,16 @@ exports.update = async (req, res) => {
   const updatedItem = await Item.update("item", req.params.itemId, itemData);
   const insertedLog = await Log.create("log", logData);
   res.send({ updatedItem, insertedLog });
+};
+
+exports.updatePosition = async (req, res) => {
+  const { order, list } = req.body;
+  const itemData = {
+    position: order,
+    list_id: list,
+  };
+  const updatedItem = await Item.update("item", req.params.itemId, itemData);
+  res.send({ updatedItem });
 };
 
 exports.delete = (req, res) => {

--- a/server/routes/items.js
+++ b/server/routes/items.js
@@ -4,7 +4,8 @@ const itemController = require("../controller/item.js");
 const router = express.Router();
 
 router.post("", itemController.create);
-router.put("/:itemId", itemController.update);
+router.put("/:itemId/content", itemController.updateContent);
+router.patch("/:itemId/position", itemController.updatePosition);
 router.delete("/:itemId", itemController.delete);
 
 module.exports = router;


### PR DESCRIPTION
아이템 드래그앤드랍시 원래 위치하던 리스트와 새롭게 위치하는 리스트의 모든 아이템에 대해 list_id, position_in_list 를 PATCH 하도록 구현.
log는 찍히지 않는 상태임.
이동을 한 후에 새로고침을 하면 위치 정보를 기억하고 있지만 이동 직후 새로 고침을 하지 않은 채 두 리스트 내에서 아이템을 생성, 삭제, 수정하면 해당 리스트는 이전 정보로 돌아가게 되는 버그가 있는 상태임.